### PR TITLE
NO-JIRA: Bump fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -6,7 +6,7 @@ include:
   - fedora-coreos-config/manifests/file-transfer.yaml
   - fedora-coreos-config/manifests/networking-tools.yaml
   - fedora-coreos-config/manifests/user-experience.yaml
-  - fedora-coreos-config/manifests/tier-x.yaml
+  - fedora-coreos-config/manifests/coreos-bootc-minimal-plus.yaml
   # RHCOS owned packages
   - packages-rhcos.yaml
 


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/bump-rhcos-submodule.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/bump-rhcos-submodule.yml)).

```
Dusty Mabe (6):
      denylist: drop toolbox test denial on rawhide
      denylist: deny ext.config.multipath.resilient on all arches
      manifests/fedora-coreos-base: add id variable
      Update fedora-bootc submodule usage
      manifests: update bootc manifest to include fedora-include/generic.yaml
      Bump bootc submodule

Jonathan Lebon (2):
      workflows: bump coreos/rhel-coreos-config submodule
      workflows/bump-rhcos-submodule: fix branch name

Michael Armijo (1):
      denylist: extend snooze for kdump.crash*
```