### PR TITLE
NO-JIRA: overrides-c10s: pin kernel to 6.12.0-71

### DIFF
--- a/c10s.repo
+++ b/c10s.repo
@@ -73,3 +73,13 @@ gpgcheck=1
 repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
+
+# https://github.com/openshift/os/issues/1818
+# This is a temporary repo serving some subpackages of kernel-6.12.0-71.el10
+# This needs to be removed once https://gitlab.com/qemu-project/qemu/-/issues/2966 is fixed.
+[c10s-kernel-6.12.0-71]
+name=CentOS Stream 10 - kernel-6.12.0-71.el10
+baseurl=https://jcapitao.fedorapeople.org/c10s-kernel-6.12.0-71/
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1

--- a/overrides-c10s.yaml
+++ b/overrides-c10s.yaml
@@ -3,8 +3,17 @@
 # we need in the `packages` section. When not needed. Empty or comment out this
 # file (except this comment).
 
+#packages:
+
 repos:
  - c10s-baseos-mirror
  - c10s-appstream-mirror
+ - c10s-kernel-6.12.0-71
 
-#packages:
+packages-ppc64le:
+ # https://github.com/openshift/os/issues/1818
+ - kernel-6.12.0-71.el10
+ - kernel-core-6.12.0-71.el10
+ - kernel-modules-6.12.0-71.el10
+ - kernel-modules-core-6.12.0-71.el10
+ - kernel-modules-extra-6.12.0-71.el10


### PR DESCRIPTION
This is a workaround for [1]. We are hitting a QEMU bug since the introduction of the kernel patch [2]. 
With the newer kernel that does not contain this patch, the tests are working.

Note that this is a workaround targeting our tooling (i.e how we run our kola tests), but on the other hand, it covers the usecase of the enduser booting the image with QEMU.

I'm using my fedorapeople.org namespace to serve the packages, let me know if there is a more proper way.

[1] https://github.com/openshift/os/issues/1818
[2] https://github.com/torvalds/linux/commit/6aa989ab2bd0d37540c812b4270006ff794662e7