### PR TITLE
NO-JIRA: overrides: drop s390utils-base pin for c9s

### DIFF
--- a/packages-overrides.yaml
+++ b/packages-overrides.yaml
@@ -3,16 +3,13 @@
 # RPMs) and list the NEVRs we need in the `packages` section. When not needed comment
 # out the sections below.
 conditional-include:
-  - if:
-    - osversion == "centos-9"
-    - basearch == "s390x"
-    include:
-      repos:
-        - c9s-baseos-mirror
-        - c9s-appstream-mirror
-      packages:
-        # https://github.com/openshift/os/issues/1731
-        - s390utils-base-2.33.1-2.el9
+##- if: osversion == "centos-9"
+##  include:
+##    repos:
+##      - c9s-baseos-mirror
+##      - c9s-appstream-mirror
+##    packages:
+##      - foo-1.2
   - if:
     - osversion == "rhel-9.6"
     - basearch == "s390x"


### PR DESCRIPTION
The newer versions of OSTree and coreos-installer are in c9s already so we can drop this pin for now. Once we get the fixes backported for RHEL 9.6 we can drop it for the `rhel-9.6` stream.

See https://github.com/openshift/os/issues/1731#issuecomment-2893156052