### PR TITLE
NO-JIRA: manifests: move composefs workaround to common.yaml

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -43,6 +43,23 @@ documentation: false
 recommends: true
 
 postprocess:
+  # Set composefs to `maybe` for now because older bootimages
+  # could be starting with an OSTree that's not new enough.
+  # https://github.com/openshift/os/issues/1678
+  # This used to be in manifest-el9-shared.yaml, but because of subtle
+  # rpm-ostree include semantics, it runs too early, i.e. before `prepare-root.conf`
+  # is actually written. This will become irrelevant when we move to `podman build`.
+  # https://github.com/coreos/rhel-coreos-config/issues/12
+  - |
+    #!/usr/bin/bash
+    set -xeuo pipefail
+    source /etc/os-release
+    # always expect the file to be there, and that it turns on composefs
+    grep -Pz '\[composefs\]\nenabled = true\n' /usr/lib/ostree/prepare-root.conf
+    if [[ $VERSION_ID = 9.* ]]; then
+      sed -i -e 's,enabled = true,enabled = maybe,' /usr/lib/ostree/prepare-root.conf
+    fi
+
   # Mark the OS as of the CoreOS variant.
   # XXX: should be part of a centos/redhat-release subpackage instead
   - |

--- a/manifest-el9-shared.yaml
+++ b/manifest-el9-shared.yaml
@@ -20,15 +20,3 @@ remove-from-packages:
 # [1]:https://issues.redhat.com/browse/RHEL-73904
 ostree-layers:
   - overlay/25rhcos-azure-udev
-
-postprocess:
-  - |
-    #!/usr/bin/bash
-    set -xeuo pipefail
-    # Set composefs to `maybe` for now because older bootimages
-    # could be starting with an OSTree that's not new enough.
-    # https://github.com/openshift/os/issues/1678
-    if [ -f /usr/lib/ostree/prepare-root.conf ]; then
-      grep -q 'enabled = true' /usr/lib/ostree/prepare-root.conf
-      sed -i -e 's,enabled = true,enabled = maybe,' /usr/lib/ostree/prepare-root.conf
-    fi

--- a/tests/kola/files/composefs-maybe
+++ b/tests/kola/files/composefs-maybe
@@ -1,0 +1,13 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+
+# This test verifies that composefs is set to maybe as a workaround for
+# https://github.com/openshift/os/issues/1678
+
+set -xeuo pipefail
+
+source /etc/os-release
+if [[ $VERSION_ID = 9.* ]]; then
+    grep -nr -Pz '\[composefs\]\nenabled = maybe' /usr/lib/ostree/prepare-root.conf
+fi


### PR DESCRIPTION
Because of unfortunate and subtle rpm-ostree include semantics, the postpocess script that flips composefs to `maybe` actually ran before `prepare-root.conf` was even written (that's done by a postprocess script in a manifest inherited by minimal-plus).

This will be much clearer once we move to `podman build` because then all postprocessing scripts from the base layer happen in a different stage entirely.

Anyway, for now just work around this by moving the composefs workaround to `common.yaml` directly and checking within it for el9. While we're here, do a few tweaks:
1. always require `prepare-root.conf` to be there; this would've caught this regression
2. strengthen the grep that checks that it turns on composefs
3. add a test that verifies the desired end state (a better test of course would be an ugprade test from an old bootimage, though we don't have the setup for that currently)

See also https://github.com/coreos/rpm-ostree/commit/7b13723898c0277239cf7f5d9c1a4eca5a6f23ee.

Fixes: ca549fe ("Require tier-x")
Fixes: https://github.com/coreos/rhel-coreos-config/issues/12