### PR TITLE
NO-JIRA: tests/kola/ext: Skip lockdown LSM test for all centos

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -99,3 +99,9 @@
 
 - pattern: ext.config.shared.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
+
+- pattern: ext.config.security.lockdown
+  tracker: https://github.com/openshift/os/issues/1237
+  osversion:
+    - centos-9
+    - centos-10


### PR DESCRIPTION
Add ext.config.security.lockdown to kola-denylist.yaml for centos version 9, 10, 10.1

Related to: https://github.com/coreos/coreos-assembler/issues/4112
Needed for: https://github.com/coreos/fedora-coreos-config/pull/3326