### PR TITLE
NO-JIRA: ci/prow-entrypoint.sh: drop `--tag !openshift`

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -79,7 +79,7 @@ cosa_build() {
 # Build QEMU image and run all kola tests
 kola_test_qemu() {
     cosa osbuild qemu
-    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet "$@"
+    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet
 }
 
 # Build metal, metal4k & live images and run kola tests
@@ -243,13 +243,13 @@ main() {
             setup_user
             cosa_init "rhel-9.6"
             cosa_build
-            kola_test_qemu --tag '!openshift'
+            kola_test_qemu
             ;;
         "rhcos-9-build-test-qemu")
             setup_user
             cosa_init "rhel-9.6"
             cosa_build
-            kola_test_qemu --tag '!openshift'
+            kola_test_qemu
             ;;
         "rhcos-9-build-test-metal")
             setup_user
@@ -267,7 +267,7 @@ main() {
             setup_user
             cosa_init "c9s"
             cosa_build
-            kola_test_qemu --tag '!openshift'
+            kola_test_qemu
             ;;
         "scos-9-build-test-metal")
             setup_user
@@ -279,7 +279,7 @@ main() {
             setup_user
             cosa_init "c10s"
             cosa_build
-            kola_test_qemu --tag '!openshift'
+            kola_test_qemu
             ;;
         "scos-10-build-test-metal")
             setup_user
@@ -291,7 +291,7 @@ main() {
             setup_user
             cosa_init "rhel-10.1"
             cosa_build
-            kola_test_qemu --tag '!openshift'
+            kola_test_qemu
             ;;
         "rhcos-10-build-test-metal")
             setup_user

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -246,22 +246,16 @@ main() {
             kola_test_qemu --tag '!openshift'
             ;;
         "rhcos-9-build-test-qemu")
-            # temporarily disabled due to
-            # https://github.com/coreos/rhel-coreos-config/issues/26
-            exit 0
-            # setup_user
-            # cosa_init "rhel-9.6"
-            # cosa_build
-            # kola_test_qemu --tag '!openshift'
+            setup_user
+            cosa_init "rhel-9.6"
+            cosa_build
+            kola_test_qemu --tag '!openshift'
             ;;
         "rhcos-9-build-test-metal")
-            # temporarily disabled due to
-            # https://github.com/coreos/rhel-coreos-config/issues/26
-            exit 0
-            # setup_user
-            # cosa_init "rhel-9.6"
-            # cosa_build
-            # kola_test_metal
+            setup_user
+            cosa_init "rhel-9.6"
+            cosa_build
+            kola_test_metal
             ;;
         "rhcos-9next-build-test-qemu")
             exit 0


### PR DESCRIPTION
This is no longer required now that we don't run OpenShift tests by default.

Requires: https://github.com/coreos/coreos-assembler/pull/4122