### PR TITLE
NO-JIRA: Drop workaround removing authselect; no longer needed with upstream fix

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -107,10 +107,9 @@ postprocess:
     rm -f /usr/lib/systemd/system/systemd-resolved.service
 
   # This updates the PAM configuration to reference all of the SSSD modules.
-  # Removes the `authselect` binary afterwards since `authselect` does not play well with `nss-altfiles`
-  # (https://github.com/pbrezina/authselect/issues/48).
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1774154
-  # NOTE: This is a temporary hack which should be updated after switching to systemd-sysusers
+  # authselect requires access to /var and more permissions to enable a profile,
+  # so we use 'authselect test' instead.
+
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
@@ -119,7 +118,6 @@ postprocess:
     for pam_file in system-auth password-auth smartcard-auth fingerprint-auth postlogin; do
       authselect test sssd --${pam_file} | tail -n +2 > /etc/pam.d/${pam_file}
     done
-    rm -f $(which authselect)
 
   # Make sure that we do not ship broken symlinks:
   # https://github.com/openshift/os/issues/1003


### PR DESCRIPTION
- The original hack removed the `authselect` binary to avoid issues with `nss-altfiles`, as authselect used to generate nsswitch configs that broke systems using this NSS module.

This workaround was necessary years ago, but upstream authselect has since added a fix to avoid this issue:
https://github.com/authselect/authselect/blob/8d289294bba22c9a0b6fa971f9735a48101c5f4a/rpm/authselect.spec.in#L210-L217

This fix is present in RHEL 9

- FIX https://github.com/openshift/os/issues/1779