### PR TITLE
NO JIRA: overrides: pin kernel-6.12.0-89.el10

### DIFF
--- a/packages-overrides.yaml
+++ b/packages-overrides.yaml
@@ -25,7 +25,7 @@ conditional-include:
       packages:
         # https://github.com/coreos/rhel-coreos-config/issues/21
         - kernel-6.12.0-89.el10
-##- if: osversion == "rhel-10.1"
-##  include:
-##    packages:
-##      - foo-1.2
+  - if: osversion == "rhel-10.1"
+    include:
+      packages:
+        - kernel-6.12.0-89.el10


### PR DESCRIPTION
The kola testiso failures in rhel-10.1 builds correlates with the recent kernel package version kernel-6.12.0-94.el10.x86_64. It was earlier checked that the kola tests seem to pass with version 6.12.0-89.el10. Hence we are pinning the kernel to version 6.12.0-89.el10

Ref: https://github.com/coreos/rhel-coreos-config/issues/21