### PR TITLE
denylist: drop denial that doesnt matter anymore

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,11 +21,6 @@
     - centos-9
     - centos-10
 
-# The 4.17 and 4.18 build of Ignition encounters a FIPS panic so
-# we are using the 4.16 build for now while that is under investigation.
-- pattern: ext.config.version.rhaos-pkgs-match-openshift
-  tracker: https://issues.redhat.com/browse/OCPBUGS-42688
-
 # This test is failing only in prow, so it's skipped by prow
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: iso-offline-install-iscsi.ibft.bios


### PR DESCRIPTION
Dropping the test ext.config.version.rhaos-pkgs-match-openshift from this list as this test doesnt make much sense in rhel-coreos-config anymore.