### PR TITLE
NO-JIRA: passwd,group: drop some newly added users and groups

### DIFF
--- a/group
+++ b/group
@@ -49,11 +49,6 @@ unbound:x:799:
 openvswitch:x:800:
 hugetlbfs:x:801:
 dockerroot:x:986:
-cockpit-ws:x:987:
-systemd-bus-proxy:x:988:
-systemd-resolve:x:989:
-systemd-network:x:990:
-systemd-timesync:x:991:
 chrony:x:992:
 sssd:x:993:
 kube:x:994:

--- a/passwd
+++ b/passwd
@@ -28,11 +28,6 @@ gluster:x:797:794:GlusterFS daemons:/run/gluster:/sbin/nologin
 systemd-coredump:x:798:796:systemd Core Dumper:/:/sbin/nologin
 unbound:x:799:799:Unbound DNS resolver:/etc/unbound:/sbin/nologin
 openvswitch:x:800:800::/:/sbin/nologin
-cockpit-ws:x:988:987:User for cockpit-ws:/:/usr/sbin/nologin
-systemd-bus-proxy:x:989:988:systemd Bus Proxy:/:/usr/sbin/nologin
-systemd-resolve:x:990:989:systemd Resolver:/:/usr/sbin/nologin
-systemd-network:x:991:990:systemd Network Management:/:/usr/sbin/nologin
-systemd-timesync:x:993:991:systemd Time Synchronization:/:/usr/sbin/nologin
 chrony:x:994:992::/var/lib/chrony:/usr/sbin/nologin
 sssd:x:995:993:User for sssd:/run/sssd:/usr/sbin/nologin
 kube:x:996:994:Kubernetes user:/:/usr/sbin/nologin


### PR DESCRIPTION
Commit 68db9a87d6bfb6f47f877d35576f8f70d648f0da synced our passwd and group with the bootc base images in preparations for rebasing to those. There are some concerns about some of the net new entries there. Let's remove them for now until we get consensus.