### PR TITLE
NO-JIRA: unpin kernel for c10s

### DIFF
--- a/packages-overrides.yaml
+++ b/packages-overrides.yaml
@@ -17,14 +17,13 @@ conditional-include:
       packages:
         # https://github.com/openshift/os/issues/1731
         - s390utils-base-2.33.1-2.el9
-  - if: osversion == "centos-10"
-    include:
-      repos:
-        - c10s-baseos-mirror
-        - c10s-appstream-mirror
-      packages:
-        # https://github.com/coreos/rhel-coreos-config/issues/21
-        - kernel-6.12.0-89.el10
+##- if: osversion == "centos-10"
+##  include:
+##    repos:
+##      - c10s-baseos-mirror
+##      - c10s-appstream-mirror
+##    packages:
+##      - foo-1.2
 ##- if: osversion == "rhel-10.1"
 ##  include:
 ##    packages:


### PR DESCRIPTION
The issue is now resolved with the kernel-6.12.0-101.el10 update.

Fixes https://github.com/openshift/os/issues/1818

This reverts commit b41d35142f710cbae7319cb77469632ddffd7465.