### PR TITLE
NO-JIRA: denylist: add ostree.remote to denylist

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -100,3 +100,12 @@
   osversion:
     - centos-9
     - centos-10
+
+- pattern: ostree.remote
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/34
+  snooze: 2025-07-05
+  osversion:
+    - centos-9
+    - centos-10
+    - rhel-9.6
+    - rhel-10.1


### PR DESCRIPTION
The ostree.remote test has been failing on c9s and c10s builds. let us add this test to the denylist for now

Ref: https://github.com/coreos/rhel-coreos-config/issues/34