### PR TITLE
denylist: add rootless podman tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -101,3 +101,21 @@
 - pattern: ext.config.shared.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
 
+- pattern: ext.config.shared.podman.rootless-systemd
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/46
+  osversion:
+    - centos-10
+    - centos-9
+
+- pattern: ext.config.shared.podman.rootless-pasta-networking
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/46
+  osversion:
+    - centos-10
+    - centos-9
+
+- pattern: ext.config.shared.podman.dns
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/46
+  osversion:
+    - centos-10
+    - centos-9
+  


### PR DESCRIPTION
Upstream bug that landed in fedora and centos simultaneously. See https://bugzilla.redhat.com/show_bug.cgi?id=2382662