### PR TITLE
NO-JIRA: packages-override: unpin shadow-utis for rhel10

### DIFF
--- a/packages-overrides.yaml
+++ b/packages-overrides.yaml
@@ -26,12 +26,6 @@ conditional-include:
         # https://bugzilla.redhat.com/show_bug.cgi?id=2382662
         - shadow-utils-4.15.0-6.el10
   - if:
-    - osversion == "rhel-10.1"
-    include:
-      packages:
-        # https://bugzilla.redhat.com/show_bug.cgi?id=2382662
-        - shadow-utils-4.15.0-6.el10
-  - if:
     - osversion == "centos-9"
     include:
       repos:


### PR DESCRIPTION
In 90fe2b0cd2dd5f782d17d9d2184ca91f6643dad8 we pinned shadow-utils to the previous released version but it has been already untagged from the repo so it won't build anyway.

Let's pull the latest and let the test fail until a new version come out.