### PR TITLE
OCPBUGS-59995: Remove 001-rhel-shortnames.conf from containers-common

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -229,6 +229,14 @@ postprocess:
     # Nuke broken alternatives links
     rm -f /etc/alternatives/*-man
 
+  # Remove 001-rhel-shortnames.conf from containers-common
+  # See: https://issues.redhat.com/browse/OCPBUGS-59995
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    rm -f /etc/containers/registries.conf.d/001-rhel-shortnames.conf
+
 # Add the sudo group to /etc/group
 # This is re-implemented below for the container-native flow. Nuke this once
 # that's the only path we support.


### PR DESCRIPTION
With the move to RHEL 9.6 and the split between the RHEL base and the OpenShift node image, we are now using the containers-common package from RHEL directly and no longer the RHAOS specific one.

This package comes with the 001-rhel-shortnames.conf configuration files which sets shortnames for container images. Those new redirections will change which image is pulled for upgrading clusters already using short names and can lead to unwanted behavior.

Thus remove it from the RHEL base image.

See: https://issues.redhat.com/browse/OCPBUGS-59995