### PR TITLE
NO-JIRA: prow-entrypoint: always prepare repos in cosa_init

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -33,17 +33,19 @@ setup_user() {
 # Setup a new build directory with COSA init, selecting the version of RHEL or
 # CentOS Stream that we want as a basis for RHCOS/SCOS.
 cosa_init() {
-    if test -d builds; then
-        echo "Already in an initialized cosa dir"
-        return
-    fi
-
     if [[ ${#} -ne 1 ]]; then
         echo "This should have been called with a single 'variant' argument"
         exit 1
     fi
     local -r variant="${1}"
     echo "Using variant: ${variant}"
+
+    if test -d builds; then
+        echo "Already in an initialized cosa dir"
+        # Pull repos from an in-cluster service of the Openshift CI
+        prepare_repos "${variant}"
+        return
+    fi
 
     # Always create a writable copy of the source repo
     tmp_src="$(mktemp -d)"


### PR DESCRIPTION
PR #44 moved `prepare_repos` to `cosa_init` because 1. we want to take advantage of the `$variant` variable defined in this function and not have to define another time in `cosa_build` 2. it feel the right place to fetch the repos during the `cosa_init` operation. But, as prepare_repos is placed after testing the existence of the 'builds' directory, the repos are not fetch when already in an intilialized cosa dir.
This changes the behavior by always fetching the repos during the `cosa_init` process.