### PR TITLE
NO-JIRA: [s390x][el9] `rhcos.network.multiple-nics` to denylist

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -101,3 +101,11 @@
 - pattern: ext.config.shared.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
 
+- pattern: rhcos.network.multiple-nics
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/54
+  snooze: 2025-08-20
+  osversion:
+    - centos-9
+    - rhel-9.6
+  arches:
+    - s390x


### PR DESCRIPTION
A recent change in COSA[1] to improve the tests fiability on s390x caused this test to fail. Let's denylist this test until it's solved to unstuck the pipeline.

See https://github.com/coreos/rhel-coreos-config/issues/54

[1] https://github.com/coreos/coreos-assembler/pull/4245