### PR TITLE
NO-JIRA: denylist - drop content-origins kola test denials

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -55,11 +55,6 @@
     - centos-10
     - rhel-10.1
 
-- pattern: ext.config.shared.content-origins
-  tracker: https://issues.redhat.com/browse/RHEL-86436
-  osversion:
-    - rhel-10.1
-
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1923
   arches:


### PR DESCRIPTION
The issue is resolved with the fixed build `gdbm-1.23-12.el10_0`, we can now drop the test from denylist entries.

Ref: https://issues.redhat.com/browse/RHEL-86436