### PR TITLE
NO-JIRA: kola-denylist: remove rpm-ostree.replace-rt-kernel

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -55,14 +55,6 @@
     - centos-10
     - rhel-10.1
 
-- pattern: ext.config.rpm-ostree.replace-rt-kernel
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1923
-  arches:
-    - ppc64le
-  osversion:
-    - centos-10
-    - rhel-10.1
-
 - pattern: ext.config.shared.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
 


### PR DESCRIPTION
The test is passing again in rhel-10.1 and centos-10.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1923