### PR TITLE
NO-JIRA: build-args-*.conf: add NAME build arg

### DIFF
--- a/build-args-c10s.conf
+++ b/build-args-c10s.conf
@@ -1,6 +1,7 @@
 # Variant-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
 
+NAME=scos
 VERSION="10.0"
 BUILDER_IMG=quay.io/centos-bootc/centos-bootc:stream10
 MANIFEST=manifest-c10s.yaml

--- a/build-args-c9s.conf
+++ b/build-args-c9s.conf
@@ -1,6 +1,7 @@
 # Variant-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
 
+NAME=scos
 VERSION="9.0"
 BUILDER_IMG=quay.io/centos-bootc/centos-bootc:stream9
 MANIFEST=manifest-c9s.yaml

--- a/build-args-rhel-10.1.conf
+++ b/build-args-rhel-10.1.conf
@@ -1,6 +1,7 @@
 # Variant-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
 
+NAME=rhcos
 VERSION="10.1"
 BUILDER_IMG=registry.stage.redhat.io/rhel10/rhel-bootc:10.1
 MANIFEST=manifest-rhel-10.1.yaml

--- a/build-args-rhel-9.6.conf
+++ b/build-args-rhel-9.6.conf
@@ -1,6 +1,7 @@
 # Variant-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
 
+NAME=rhcos
 VERSION="9.6"
 BUILDER_IMG=registry.redhat.io/rhel9/rhel-bootc:9.6
 MANIFEST=manifest-rhel-9.6.yaml


### PR DESCRIPTION
This is used as a label in the latest Containerfile and is what ends up being used e.g. to name artifacts.

See also: https://github.com/coreos/fedora-coreos-config/pull/3584