### PR TITLE
NO-JIRA: kola-denylist: remove ext.config.version.rhel-major-version

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -48,13 +48,6 @@
     - centos-10
     - rhel-10.1
 
-# Will fail until we have proper RHEL 10 builds of OCP packages
-- pattern: ext.config.version.rhel-major-version
-  tracker: https://issues.redhat.com/browse/ART-11112
-  osversion:
-    - centos-10
-    - rhel-10.1
-
 - pattern: ext.config.shared.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
 


### PR DESCRIPTION
The` ext.config.version.rhel-major-version` test is passing again in `rhel-10.1` and `centos-10` so we are removing from` kola-denylist.yaml`.

