### PR TITLE
Revert "packages-override: unpin s390utils-base"

### DIFF
--- a/packages-overrides.yaml
+++ b/packages-overrides.yaml
@@ -11,6 +11,13 @@ conditional-include:
 ##    packages:
 ##      - foo-1.2
   - if:
+    - osversion == "rhel-9.6"
+    - basearch == "s390x"
+    include:
+      packages:
+        # https://github.com/openshift/os/issues/1731
+        - s390utils-base-2.33.1-2.el9
+  - if:
     - osversion == "centos-10"
     include:
       repos:


### PR DESCRIPTION
This reverts commit b82bbaf74d8fb15259fe711bad4ad1b8630697b3.

We still have the old coreos-installer and ostree-2025 RPMs currently, so we still need to pin it.