### PR TITLE
denylist: add luks.cex for centOS

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -58,3 +58,11 @@
   tracker: https://github.com/coreos/rhel-coreos-config/issues/70
   osversion:
     - rhel-9.6
+
+# This test won't run on non-rhcos, but kola thinks SCOS is RHCOS
+# See https://github.com/coreos/coreos-assembler/pull/4334
+- pattern: luks.cex
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/76
+  osversion:
+    - centos-9
+    - centos-10


### PR DESCRIPTION
This test requires some magic that only exists on RHCOS s390x builders. Let's denylist these tests to unblock the pipeline until we fix cosa to know to ignore centos for this.

Tracking issue https://github.com/coreos/rhel-coreos-config/issues/76 See https://github.com/coreos/coreos-assembler/pull/4334