### PR TITLE
NO-JIRA: denylist: add secex tests for s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -59,10 +59,24 @@
   osversion:
     - rhel-9.6
 
-# This test won't run on non-rhcos, but kola thinks SCOS is RHCOS
-# See https://github.com/coreos/coreos-assembler/pull/4334
+# Require a release of coreos-installer
+# https://github.com/coreos/coreos-installer/issues/1695
 - pattern: luks.cex
   tracker: https://github.com/coreos/rhel-coreos-config/issues/76
+  snooze: 2025-10-15
+  arches:
+    - s390x
+  osversion:
+    - centos-9
+    - centos-10
+
+# require a new release of coreos-installer
+# https://github.com/coreos/coreos-installer/issues/1695
+- pattern: ext.config.shared.secex.*
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/76
+  snooze: 2025-10-15
+  arches:
+    - s390x
   osversion:
     - centos-9
     - centos-10


### PR DESCRIPTION
These tests require a new release of coreos-installer Snooze them for a couple of weeks until the release is out.

See https://github.com/coreos/coreos-installer/issues/1695 See https://github.com/coreos/rhel-coreos-config/issues/76