### PR TITLE
packages-override: unpin s390utils-base

### DIFF
--- a/packages-overrides.yaml
+++ b/packages-overrides.yaml
@@ -10,13 +10,6 @@ conditional-include:
 ##      - c9s-appstream-mirror
 ##    packages:
 ##      - foo-1.2
-  - if:
-    - osversion == "rhel-9.6"
-    - basearch == "s390x"
-    include:
-      packages:
-        # https://github.com/openshift/os/issues/1731
-        - s390utils-base-2.33.1-2.el9
 ##- if: osversion == "centos-10"
 ##  include:
 ##    repos:


### PR DESCRIPTION
The secex tests are passing after the backport of ostree and coreos-installer fixes

Ref:
The below packages have released now
ostree - https://issues.redhat.com/browse/RHEL-93000 
coreos-installer - https://issues.redhat.com/browse/RHEL-93001 
https://github.com/openshift/os/issues/1731