### PR TITLE
OCPBUGS-62699: Revert inclusion of AWS ECR credential provider in RHEL layer

### DIFF
--- a/manifest-rhel-10.1.yaml
+++ b/manifest-rhel-10.1.yaml
@@ -30,10 +30,3 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-process script
  - redhat-release
- # XXX: This should be in packages-openshift.yaml only. For now,
- # it's in the base until the equivalent functionality lands in RHEL:
- # https://issues.redhat.com/browse/RHEL-82921
- # XXX: commented out in RHEL10.1 because the rhel-10.1-early-kernel
- # repo doesn't exist yet. In 9.6 this is provided by the rhel-9.6-early-kernel
- # yum repo.
- # - ose-aws-ecr-image-credential-provider

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -30,7 +30,3 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-process script
  - redhat-release
- # XXX: This should be in packages-openshift.yaml only. For now,
- # it's in the base until the equivalent functionality lands in RHEL:
- # https://issues.redhat.com/browse/RHEL-82921
- - ose-aws-ecr-image-credential-provider


### PR DESCRIPTION
This was added as a workaround for ROSA, but is now causing issues when building/shipping OCP as we are shipping the incorrect versions of the binary in release 4.20 and 4.21.

ROSA are working on an alternative workaround which will allow us to revert this, targeting end of October for merge.
/hold 