### PR TITLE
denylist ext.config.systemd.journal-compat

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -80,3 +80,11 @@
   osversion:
     - centos-9
     - centos-10
+
+# podman fails to pull ubi8 images due to missing sigstore
+# annotation
+- pattern: ext.config.systemd.journal-compat
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/85
+  osversion:
+    - rhel-10.1
+    - centos-10


### PR DESCRIPTION
The ubi8 images are missing the correct sigstore annotations to be verified by podman. Let's disable this test until we get that fixed.

tracker: https://github.com/coreos/rhel-coreos-config/issues/85