### PR TITLE
NO-JIRA: Revert "denylist ext.config.systemd.journal-compat"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -80,11 +80,3 @@
   osversion:
     - centos-9
     - centos-10
-
-# podman fails to pull ubi8 images due to missing sigstore
-# annotation
-- pattern: ext.config.systemd.journal-compat
-  tracker: https://github.com/coreos/rhel-coreos-config/issues/85
-  osversion:
-    - rhel-10.1
-    - centos-10


### PR DESCRIPTION
This reverts commit 775c201fa0324123920f838a01c31acebf816cc4. The image was re-signed manually.

See https://issues.redhat.com/browse/CLOUDDST-29221 And https://groups.google.com/a/redhat.com/g/konflux-announce/c/nkeULdIsd6c