### PR TITLE
NO-JIRA: denylist: remove snooze for s390x secex tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -63,7 +63,6 @@
 # https://github.com/coreos/coreos-installer/issues/1695
 - pattern: luks.cex
   tracker: https://github.com/coreos/rhel-coreos-config/issues/76
-  snooze: 2025-10-15
   arches:
     - s390x
   osversion:
@@ -74,7 +73,6 @@
 # https://github.com/coreos/coreos-installer/issues/1695
 - pattern: ext.config.shared.secex.*
   tracker: https://github.com/coreos/rhel-coreos-config/issues/76
-  snooze: 2025-10-15
   arches:
     - s390x
   osversion:


### PR DESCRIPTION
The fixes requires releases of ignition and coreos-installer. 
Let's denylist them indefinitely.

See https://github.com/coreos/rhel-coreos-config/issues/76