### PR TITLE
NO-JIRA: image-rhel-10.1: use -Efragments for erofs creation

### DIFF
--- a/image-rhel-10.1.yaml
+++ b/image-rhel-10.1.yaml
@@ -33,4 +33,4 @@ aws-x86-boot-mode: "legacy-bios"
 
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
 live-rootfs-fstype: "erofs"
-live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"
+live-rootfs-fsoptions: "-zlzma,level=6 -Efragments -C1048576 --quiet"


### PR DESCRIPTION
As suggested by the maintainer we'll change this option from `-Eall-fragments,fragdedupe=inode` to -Efragments.

See https://github.com/coreos/fedora-coreos-tracker/issues/1991