### PR TITLE
NO-JIRA: build-args: Add STREAM to build-args

### DIFF
--- a/build-args-c10s.conf
+++ b/build-args-c10s.conf
@@ -7,3 +7,4 @@ BUILDER_IMG=quay.io/centos-bootc/centos-bootc:stream10
 MANIFEST=manifest-c10s.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=.
+STREAM=c10s

--- a/build-args-c9s.conf
+++ b/build-args-c9s.conf
@@ -7,3 +7,4 @@ BUILDER_IMG=quay.io/centos-bootc/centos-bootc:stream9
 MANIFEST=manifest-c9s.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=.
+STREAM=c9s

--- a/build-args-rhel-10.1.conf
+++ b/build-args-rhel-10.1.conf
@@ -7,3 +7,4 @@ BUILDER_IMG=registry.stage.redhat.io/rhel10/rhel-bootc:10.1
 MANIFEST=manifest-rhel-10.1.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=.
+STREAM=rhel-10.1

--- a/build-args-rhel-9.6.conf
+++ b/build-args-rhel-9.6.conf
@@ -7,3 +7,4 @@ BUILDER_IMG=registry.redhat.io/rhel9/rhel-bootc:9.6
 MANIFEST=manifest-rhel-9.6.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=.
+STREAM=rhel-9.6


### PR DESCRIPTION
This commit adds the STREAM build argument to all build-args configs so the `com.coreos.stream` label can be consistently populated during image builds.

See: https://github.com/coreos/fedora-coreos-config/pull/3867