### PR TITLE
NO-JIRA: move /etc/localtime symlinking to be el9 only

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -181,15 +181,6 @@ postprocess:
     echo '# RHCOS-only: we follow the Fedora/upstream default' >> /usr/lib/systemd/system/basic.target
     echo 'Wants=tmp.mount' >> /usr/lib/systemd/system/basic.target
 
-  - |
-    #!/usr/bin/env bash
-    set -xeo pipefail
-    # See https://issues.redhat.com/browse/LOG-3117
-    # Something changed between rhel8 and rhel9 to not generate this by default
-    # but we have containers that expect it to be mounted so for now let's continue
-    # generating it.
-    ln -sr /usr/share/zoneinfo/UTC /etc/localtime
-
   # sudo prefers its config files to be mode 440, and some security scanners
   # complain if /etc/sudoers.d files are world-readable.
   # https://bugzilla.redhat.com/show_bug.cgi?id=1981979

--- a/manifest-el9-shared.yaml
+++ b/manifest-el9-shared.yaml
@@ -13,11 +13,22 @@ packages:
 ostree-layers:
   - overlay/25rhcos-azure-udev
 
-# zram-generator-0.3.2 (shipped in centOS 9) provides a default zram-generator
-# config, we want to disable it. We don't need this in el10 because the config
-# was split in a subpackage we don't pull in.
 postprocess:
+  # zram-generator-0.3.2 (shipped in centOS 9) provides a default zram-generator
+  # config, we want to disable it. We don't need this in el10 because the config
+  # was split in a subpackage we don't pull in.
   - |
     #!/usr/bin/bash
     set -xeuo pipefail
     rm /usr/lib/systemd/zram-generator.conf
+
+  # We added this for https://issues.redhat.com/browse/LOG-3117
+  # because something changed between rhel8 and rhel9 to not
+  # generate this by default but we had containers that expected it
+  # to exist to be mounted. We include it in RHEL 9, but the
+  # containers were fixed in [1] so we won't include it in RHEL 10.
+  # [1] https://github.com/openshift/cluster-logging-operator/pull/1675
+  - |
+    #!/usr/bin/env bash
+    set -xeo pipefail
+    ln -sr /usr/share/zoneinfo/UTC /etc/localtime

--- a/tests/kola/files/localtime
+++ b/tests/kola/files/localtime
@@ -1,12 +1,21 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify /etc/localtime link exists.
-##     https://github.com/openshift/os/pull/1021
-##     https://issues.redhat.com/browse/LOG-3117
+##   description: Verify /etc/localtime state.
+##     Symlink was added in el9 for
+##         https://github.com/openshift/os/pull/1021
+##         https://issues.redhat.com/browse/LOG-3117
+##     Symlink was removed in el10+
+##         https://github.com/coreos/rhel-coreos-config/pull/103
 
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-test -L /etc/localtime
+if match_maj_ver "9"; then
+    test -L /etc/localtime
+    ok "/etc/localtime symlink exists"
+else
+    test ! -e /etc/localtime
+    ok "/etc/localtime does not exist"
+fi


### PR DESCRIPTION
We added the symlinking for https://issues.redhat.com/browse/LOG-3117 because something changed between rhel8 and rhel9 to not generate this by default but we had containers that expected it to exist to be mounted. Let's continue to include this in RHEL9 but since the containers were fixed in [1] let's not include it in RHEL 10 based CoreOS.

[1] https://github.com/openshift/cluster-logging-operator/pull/1675