### PR TITLE
NO-JIRA: [rhel-10.1] denylist: snooze `ext.config.systemd.journal-compat` on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -46,3 +46,12 @@
   warn: true
   osversion:
     - rhel-10.1
+
+- pattern: ext.config.systemd.journal-compat
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/85
+  snooze: 2025-12-08
+  warn: true
+  osversion:
+    - rhel-10.1
+  arches:
+    - s390x


### PR DESCRIPTION
This test started failing again but only on 390x. Let's snooze the test for 2 weeks to not block the pipeline while we investigate the failure.

see: https://github.com/coreos/rhel-coreos-config/issues/85