### PR TITLE
NO-JIRA: denylist: snooze fips.enable on centos-9/10

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -46,6 +46,8 @@
   warn: true
   osversion:
     - rhel-10.1
+    - centos-9
+    - centos-10
 
 - pattern: ext.config.systemd.journal-compat
   tracker: https://github.com/coreos/rhel-coreos-config/issues/85


### PR DESCRIPTION
Test fails on c9s and c10s with:
```
files: createFilesystemsFiles: createFiles: op(4): GET error: Get "https://ignition-test-fixtures.s3.amazonaws.com/resources/anonymous": crypto/ecdh: invalid random source in FIPS
```
Deny it until we get new ignition.