### PR TITLE
denlylist: add `multipath.single-disk` for 10.1

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -29,6 +29,13 @@
   osversion:
     - rhel-10.1
 
+# Fast-track is not available for rhel-10.1, it is available only for rhel-9.6.
+- pattern: multipath.single-disk
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/113
+  snooze: 2025-12-19
+  osversion:
+    - rhel-10.1
+
 - pattern: ext.config.shared.boot.install-bootloader-multipath
   tracker: https://github.com/coreos/rhel-coreos-config/issues/99
   osversion:


### PR DESCRIPTION
Since fast-track is not available for rhel-10.1, it is available only for rhel-9.6.

See https://github.com/coreos/rhel-coreos-config/issues/113