### PR TITLE
NO-JIRA: denylist: remove systemd.journal-compat

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -59,11 +59,3 @@
     - centos-9
     - centos-10
 
-- pattern: ext.config.systemd.journal-compat
-  tracker: https://github.com/coreos/rhel-coreos-config/issues/85
-  snooze: 2025-12-08
-  warn: true
-  osversion:
-    - rhel-10.1
-  arches:
-    - s390x


### PR DESCRIPTION
This test is passing again on `[rhel10][s390x]`.

See: https://github.com/coreos/rhel-coreos-config/issues/85