### PR TITLE
NO-JIRA: image-rhel-10.1.yaml: dont add ocp labels to images

### DIFF
--- a/image-rhel-10.1.yaml
+++ b/image-rhel-10.1.yaml
@@ -10,9 +10,10 @@ deploy-via-container: true
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-# add the requisite OCP metadata to our container image
-# but xref https://github.com/openshift/os/issues/1047
-ostree-container-inject-openshift-cvo-labels: true
+# dont add the OCP metadata to our container image since it's causing
+# conflicts with rhel-9 images in the same payload.
+# but xref https://github.com/openshift/os/issues/1047#issuecomment-3608508561
+ostree-container-inject-openshift-cvo-labels: false
 
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055


### PR DESCRIPTION
Drop the labels from RHEL10 based images as a temporary measure. This allows images to be included in the 4.21 payload without breaking the reporting and RPM diff generation for the current RHEL9 based images.

See: https://github.com/openshift/os/issues/1047#issuecomment-3608508561