### PR TITLE
NO-JIRA: denylist: snooze secureboot tests on c9s

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -64,3 +64,31 @@
     - centos-9
     - centos-10
 
+# Secureboot in CentOS Stream 9 regressed.
+# - https://github.com/coreos/rhel-coreos-config/issues/130
+# - https://issues.redhat.com/browse/RHEL-137210
+- pattern: basic.uefi-secure
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/130
+  snooze: 2026-01-30
+  warn: true
+  osversion:
+    - centos-9
+- pattern: ext.config.shared.security.lockdown
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/130
+  snooze: 2026-01-30
+  warn: true
+  osversion:
+    - centos-9
+- pattern: iso-as-disk.uefi-secure
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/130
+  snooze: 2026-01-30
+  warn: true
+  osversion:
+    - centos-9
+- pattern: iso-live-login.uefi-secure
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/130
+  snooze: 2026-01-30
+  warn: true
+  osversion:
+    - centos-9
+


### PR DESCRIPTION
The newer kernel in c9s seems to cause secureboot instances to fail to boot. See [1] [2]

[1] https://github.com/coreos/rhel-coreos-config/issues/130
[2] https://issues.redhat.com/browse/RHEL-137210