### PR TITLE
denylist: Remove fips.enable

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,21 +28,6 @@
     - centos-10
     - rhel-10.1
 
-# Our fips test became more strict in [1] but we need an updated
-# ignition [2] in order for the test to pass. Let's just snooze
-# the test until we can get that updated Ignition.
-# [1] https://github.com/coreos/coreos-assembler/pull/4373
-# [2] https://issues.redhat.com/browse/RHEL-129425
-- pattern: fips.enable
-  tracker: https://issues.redhat.com/browse/RHEL-129425
-  snooze: 2026-01-12
-  warn: true
-  osversion:
-    - rhel-10.1
-    - rhel-9.8
-    - centos-9
-    - centos-10
-
 # Secureboot in CentOS Stream 10 regressed.
 # - https://github.com/coreos/rhel-coreos-config/issues/130
 # - https://issues.redhat.com/browse/RHEL-137210


### PR DESCRIPTION
A new ignition pkg has released and that has resolved this fips.enable failure. We can remove this entry from the denylist now.