### PR TITLE
NO-JIRA: denylist: Re-add fips.enable for c9s and rhel-9.8

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -56,3 +56,11 @@
   osversion:
     - centos-10
 
+# Ignition package update for c9s is currently blocked due to upstream kola test failures.
+# Keeping this denylisted until the updated Ignition package can be released.
+- pattern: fips.enable
+  tracker: https://issues.redhat.com/browse/RHEL-129425
+  osversion:
+    - centos-9
+    - rhel-9.8
+


### PR DESCRIPTION
The Ignition package update for c9s is currently blocked due to upstream kola test failures. Re-adding denylist entries for centos-9 and rhel-9.8 until the updated package can be released.