### PR TITLE
NO-JIRA: denylist: Drop ostree.sync test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,16 +12,6 @@
 #- pattern: pxe-offline-install.rootfs-appended.bios
 #  tracker: https://github.com/openshift/os/issues/1768
 
-# We are blocked waiting for the release of s390utils 2.39.0 rpm.
-# Snoozing this test until the end of January 2026 to allow time
-# for the package update to land.
-- pattern: ostree.sync
-  tracker: https://github.com/openshift/os/issues/1720
-  snooze: 2026-01-31
-  warn: true
-  arches:
-    - s390x
-
 - pattern: ostree.sync
   tracker: https://github.com/openshift/os/issues/1751
   osversion:


### PR DESCRIPTION
We can drop the ostree.sync test from the denylist as the fixed version s390-utils (s390utils-base-2:2.39.0-1.el9.s390x) pkg is now available in c9s and rhel-9.8 streams.