### PR TITLE
tests: add new test to verify RHCOS system detection on s390x

### DIFF
--- a/tests/kola/cpi-level/data/commonlib.sh
+++ b/tests/kola/cpi-level/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/cpi-level/rhcos-system-level.sh
+++ b/tests/kola/cpi-level/rhcos-system-level.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   description: Verify that system is correctly detected on s390x
+##   architectures: s390x
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+level=$(cat /sys/firmware/cpi/system_level)
+
+# https://www.ibm.com/docs/en/linux-on-systems?topic=identification-system-level
+# This may look like:
+#   on QEMU - 0x070906023a050e00
+#   on LPAR - 0x870906023a050e00
+if is_rhcos && [[ ! "${level}" =~ ^0x.7 ]]; then
+    fatal "RHCOS system detection failed: expected 0x.7... but got ${level}"
+fi


### PR DESCRIPTION
RHCOS was incorrectly showing in HMC as RHEL because `system_level` value was wrong. This test verifies the fix introduced in s390-tools PR https://github.com/ibm-s390-linux/s390-tools/pull/199, ensuring that `/sys/firmware/cpi/system_level` correctly identifies the OS as RHCOS.