### PR TITLE
denylist: extend kernel-replace snooze

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,7 +6,7 @@
 # kernel patch exposing that device haven't landed
 # yet.
 - pattern: ext.config.shared.rpm-ostree.kernel-replace
-  snooze: 2026-03-31
+  snooze: 2026-04-13
   arches:
     - s390x
   tracker: https://github.com/coreos/rhel-coreos-config/issues/150


### PR DESCRIPTION
Test is still failing on s390x.