### PR TITLE
[rhel-9.6] COS-4019: Add the fcoe-utils package

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -302,6 +302,8 @@ packages:
  - 'dnf-command(versionlock)'
  # https://issues.redhat.com/browse/OCPBUGS-35247
  - subscription-manager
+ # Support for Fibre Channel over Ethernet (FCoE)
+ - fcoe-utils
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized

--- a/common.yaml
+++ b/common.yaml
@@ -302,8 +302,6 @@ packages:
  - 'dnf-command(versionlock)'
  # https://issues.redhat.com/browse/OCPBUGS-35247
  - subscription-manager
- # Support for Fibre Channel over Ethernet (FCoE)
- - fcoe-utils
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized
@@ -319,6 +317,8 @@ packages-x86_64:
   - WALinuxAgent-udev
   # Daemon that provides placement advice for efficient use of CPUs and memory on systems with NUMA topology.
   - numad
+  # Support for Fibre Channel over Ethernet (FCoE)
+  - fcoe-utils
 
 packages-ppc64le:
   - irqbalance

--- a/tests/kola/fcoe/can-enable-fcoe
+++ b/tests/kola/fcoe/can-enable-fcoe
@@ -1,0 +1,25 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   description: Verify that when properly configured, Fibre Channel
+##     over Ethernet (FCoE) support can be enabled via fcoe.service
+##     added by fcoe-utils, and lldpad.service added by its dependency.
+##   # fcoe-utils is currently limited to x86_64
+##   architectures: x86_64
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. $KOLA_EXT_DATA/commonlib.sh
+
+if [ "$(systemctl is-active lldpad)" != 'active' ]; then
+    systemctl status lldpad
+    fatal "lldpad.service is not active - ensure the correct kernel modules are enabled"
+fi
+
+if [ "$(systemctl is-active fcoe)" != 'active' ]; then
+    systemctl status fcoe
+    fatal "fcoe.service is not active - ensure the correct kernel modules are enabled"
+fi
+
+ok "lldpad and fcoe services can be activated when the system is correctly configured"

--- a/tests/kola/fcoe/config.bu
+++ b/tests/kola/fcoe/config.bu
@@ -1,0 +1,18 @@
+variant: fcos
+version: 1.5.0
+systemd:
+  units:
+    - name: lldpad.service
+      enabled: true
+    - name: fcoe.service
+      enabled: true
+storage:
+  files:
+    # Enable kernel modules for FCoE support in RHEL
+    # See: <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_storage_devices/configuring-fibre-channel-over-ethernet_managing-storage-devices>
+    - path: /etc/modules-load.d/fcoe.conf
+      contents:
+        inline: |
+          qedf
+          bnx2fc
+          fnic

--- a/tests/kola/fcoe/data/commonlib.sh
+++ b/tests/kola/fcoe/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh


### PR DESCRIPTION
Backport of the commits adding the `fcoe-utils` package and its test

Related PRs:

- https://github.com/coreos/rhel-coreos-config/pull/160
- https://github.com/coreos/rhel-coreos-config/pull/174
- https://github.com/coreos/rhel-coreos-config/pull/183