### PR TITLE
[rhel-9.6] OCPBUGS-82523: passwd & group: Add containers user & group

### DIFF
--- a/group
+++ b/group
@@ -38,6 +38,7 @@ input:x:104:
 ceph:x:167:
 avahi-autoipd:x:170:
 systemd-journal:x:190:
+containers:x:790:
 systemd-journal-remote:x:791:
 dnsmasq:x:792:
 clevis:x:793:

--- a/group
+++ b/group
@@ -47,7 +47,7 @@ systemd-coredump:x:796:
 render:x:797:
 unbound:x:799:
 openvswitch:x:800:
-hugetlbfs:x:801:
+hugetlbfs:x:801:openvswitch
 dockerroot:x:986:
 chrony:x:992:
 sssd:x:993:

--- a/passwd
+++ b/passwd
@@ -21,6 +21,7 @@ dbus:x:81:81:System Message Bus:/:/usr/sbin/nologin
 nobody:x:99:99:Kernel Overflow User:/:/usr/sbin/nologin
 ceph:x:167:167:Ceph daemons:/var/lib/ceph:/usr/sbin/nologin
 avahi-autoipd:x:170:170:Avahi IPv4LL Stack:/var/lib/avahi-autoipd:/usr/sbin/nologin
+containers:x:790:790:User for rootless containers:/nonexistent:/sbin/nologin
 systemd-journal-remote:x:794:791:Journal Remote:/var/log/journal/remote:/sbin/nologin
 dnsmasq:x:795:792:Dnsmasq DHCP and DNS server:/var/lib/dnsmasq:/usr/sbin/nologin
 clevis:x:796:793:Clevis Decryption Framework unprivileged user:/var/cache/clevis:/usr/sbin/nologin


### PR DESCRIPTION
Backport of https://github.com/coreos/rhel-coreos-config/pull/224

---

group: Add openvswitch to hugetlbfs group

The openvswitch user and group have been part of the passwd & group
files for, at least, as long as we've published RHCOS sources publicly:
- https://github.com/openshift/os/blame/bdb5b8153ed68c88e2485d9e7bd66ea6eb54d6c1/passwd#L27
- https://github.com/openshift/os/blame/release-4.19/group#L47

We did not remove them when we re-visited our fixed UIDs/GID in the
split between the RHEL boot image and the new OCP node image ([1], [2] &
[3]). Thus they are now part of the base RHEL boot image, even though
the openvswitch package is not included there.

Although technically unnecessary, this is fine and simplify things a bit
as we do not have to update the user & group entries during the node
image build, which is currently a problematic topic (see [4]).

Thus instead of adding openvswitch to hugetlbfs group in the node image
build, we add it here directly to simplify the logic.

[1] https://github.com/openshift/os/pull/1661
[2] https://github.com/coreos/rhel-coreos-config/pull/29
[3] https://github.com/coreos/rhel-coreos-config/pull/31
[4] https://github.com/openshift/os/pull/1917

---

passwd & group: Add containers user & group

Adding users and groups during a container image layered build is
currently non-ergonomic with bootable containers. Thus instead of doing
that in openshift/os for the node layer, we directly include the user &
group here, which also guarentees us that the UID/GID remain stable.

See https://github.com/openshift/os/pull/1917 for the original version
of this change and the full details about what makes adding user/group
in the node layer non-ergonomic.

Unfortunately we can not use the UID/GID that were used in the last
"full" RHCOS image (4.18) as those are now used for dnsmasq (see [1]).
Thus use the first UID & GID available for both user and group, going
downward.

[1] https://github.com/openshift/os/pull/1917#issuecomment-4133448515

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-64841