### PR TITLE
NO-JIRA: manifest/common: Add lldpad for LLDP support - 9.6

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -261,6 +261,8 @@ packages:
  # Networking
  - nfs-utils
  - dnsmasq
+ # Link Layer Discovery Protocol (LLDP) agent daemon for DCB
+ - lldpad
  # needed for rpm-ostree today
  - polkit
  # Extra runtime


### PR DESCRIPTION
Add the lldpad package to provide Link Layer Discovery Protocol (LLDP) support for network discovery and Data Center Bridging (DCB).

Closes: https://redhat.atlassian.net/browse/COS-3653
Assisted-by: Opencode (Opus 4.5)