### PR TITLE
OCPBUGS-83404: overlay/05rhcos: omit the dracut `drm` module by default due to its size

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/dracut.conf.d/rhcos-omits.conf
+++ b/overlay.d/05rhcos/usr/lib/dracut/dracut.conf.d/rhcos-omits.conf
@@ -2,3 +2,7 @@
 # https://bugzilla.redhat.com/show_bug.cgi?id=1700056
 # https://bugzilla.redhat.com/show_bug.cgi?id=1645772
 omit_drivers+=" nouveau "
+# The drm dracut module greatly increases the size of the initrd,
+# (~39MB as of writing this) since it pulls in a lot of GPU firmware.
+# https://redhat.atlassian.net/browse/OCPBUGS-83404
+omit_dracutmodules+=" drm "


### PR DESCRIPTION
This dracut module currently adds around 39MB to the initrd since it pulls a lot of GPU firmware. Omit the module by default so we can keep the size of our initrd down.

See https://redhat.atlassian.net/browse/OCPBUGS-83404