### PR TITLE
COS-4291: manifests/el10: add sos for collecting system logs and other info

### DIFF
--- a/manifest-el10-shared.yaml
+++ b/manifest-el10-shared.yaml
@@ -4,6 +4,13 @@ packages:
   # Include the default set of audit rules. Split from the audit package as a
   # recommends in EL10.
   - audit-rules
+  # Tool for collecting system logs and other information.
+  # Including this in our image directly allows us to transition from
+  # coreos/toolbox to containers/toolbox without waiting for both sos to
+  # support toolbox and for toolbox images to include sos.
+  - sos
+  # Used by sos, which also gives a warning if it's not available
+  - python3-file-magic
 
 packages-x86_64:
   # Include AMD microcode firmwares. Split from the linux-firmware package as a


### PR DESCRIPTION
This allows us to proceed with the transition from coreos/toolbox to containers/toolbox without waiting for both `sos report` to support running in `toolbox` and for `toolbox` images to include `sos`.

## Package + deps

```
Added:
  python3-packaging-24.2-2.el10
  python3-pexpect-4.9.0-6.el10
  python3-ptyprocess-0.7.0-9.el10
  python3-pyyaml-6.0.1-19.el10
  python3-setuptools-69.0.3-12.el10_0
  sos-4.10.2-2.el10_2
 ```
 
 Sizes:
 
 ```
 $ rpm -q --queryformat='%{NAME} %{SIZE}\n' sos python3-setuptools python3-pyyaml python3-ptyprocess python3-pexpect python3-packaging
sos 4132425
python3-setuptools 7489822
python3-pyyaml 800922
python3-ptyprocess 81852
python3-pexpect 644432
python3-packaging 570729
```

Total is about 13.7MB (13720182).

## Warnings

`sos` gives a warning if running without `python3-file-magic`:

```
WARNING: Failed to load 'magic' module version >= 0.4.20 which sos aims
to use for detecting binary files. A less effective method will be used.
It is recommended to install proper python3-magic package with the
module.
```

That package is ~30kB (29812) - should I just include it too?

Not sure if relevant but also seeing these when running `sos report` in a RHCOS 10.2 build:

```
[plugin:firewall_tables] skipped command 'nft -a list ruleset': required kmods missing: nf_tables.   Use '--allow-system-changes' to enable collection.
[plugin:firewall_tables] skipped command 'iptables -vnxL': required kmods missing: iptable_filter, nf_tables.
[plugin:firewall_tables] skipped command 'ip6tables -vnxL': required kmods missing: ip6table_filter, nf_tables.
[plugin:fwupd] skipped command 'fwupdmgr get-approved-firmware': required services missing: fwupd.
[plugin:fwupd] skipped command 'fwupdmgr get-devices --no-unreported-check': required services missing: fwupd.
[plugin:fwupd] skipped command 'fwupdmgr get-history': required services missing: fwupd.
[plugin:fwupd] skipped command 'fwupdmgr get-remotes': required services missing: fwupd.
[plugin:fwupd] skipped command '/usr/libexec/fwupd/fwupdagent get-devices': required services missing: fwupd.
[plugin:fwupd] skipped command '/usr/libexec/fwupd/fwupdagent get-updates': required services missing: fwupd.
[plugin:networking] skipped command 'ip -s macsec show': required kmods missing: macsec.   Use '--allow-system-changes' to enable collection.
[plugin:networking] skipped command 'ss -peaonmi': required kmods missing: xsk_diag.   Use '--allow-system-changes' to enable collection.
[plugin:sssd] skipped command 'sssctl config-check': required services missing: sssd.
[plugin:sssd] skipped command 'sssctl domain-list': required services missing: sssd.
[plugin:systemd] skipped command 'resolvectl status': required services missing: systemd-resolved.
[plugin:systemd] skipped command 'resolvectl statistics': required services missing: systemd-resolved.
```