### PR TITLE
NO-JIRA: denylist: remove `fips.enable.tls`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,12 +11,3 @@
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: pxe-offline-install.rootfs-appended.bios
 #  tracker: https://github.com/openshift/os/issues/1768
-
-- pattern: fips.enable.tls
-  snooze: 2026-05-01
-  tracker: https://github.com/coreos/rhel-coreos-config/issues/204
-  streams:
-    - rhel-9.8
-    - rhel-10.2
-    - c9s
-    - c10s


### PR DESCRIPTION
This test was reverted from coreos assembler, so let's remove the denylist entry while we investigate a new way to perform the test.

See: https://github.com/coreos/coreos-assembler/commit/361b1aff7c9db19f8145026fcfb39bd80deb7aa8 and https://github.com/coreos/coreos-assembler/issues/4520