### PR TITLE
NO-JIRA: ci/prow: drop testiso usage in favor of kola run

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -74,31 +74,23 @@ prepare_repos() {
     src/config/ci/get-ocp-repo.sh src/config/ocp.repo "${variant}"
 }
 
-# Do a cosa build only.
+# Build OS container and bootimage artifacts
 # This is called both as part of the build phase and test phase in Prow thus we
 # can not do any kola testing in this function.
-# We do not build the QEMU image here as we don't need it in the pure container
-# test case.
 cosa_build() {
     cosa fetch # used for the non build-with-buildah path
     cosa build
+    cosa osbuild qemu metal metal4k live
+    cosa compress --artifact=metal --artifact=metal4k
 }
 
-# Build QEMU image and run all kola tests
+# Run all kola tests
 kola_test_qemu() {
-    cosa osbuild qemu
     cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet
 }
 
-# Build metal, metal4k & live images and run kola tests
+# Run kola iso.* tests
 kola_test_metal() {
-    # Build metal + installer now so we can test them
-    cosa osbuild metal metal4k live
-
-    # Compress the metal and metal4k images now so we're testing
-    # installs with the image format we ship
-    cosa compress --artifact=metal --artifact=metal4k
-
     # Use 'testiso' for older cosa builds, otherwise use kola.
     # Until RHCOS openshift cluster gets updated, iso.* tests run sequentially.
     if cosa kola help | grep -q testiso; then

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -78,7 +78,6 @@ prepare_repos() {
 # This is called both as part of the build phase and test phase in Prow thus we
 # can not do any kola testing in this function.
 cosa_build() {
-    cosa fetch # used for the non build-with-buildah path
     cosa build
     cosa osbuild qemu metal metal4k live
     cosa compress --artifact=metal --artifact=metal4k

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -90,7 +90,7 @@ kola() {
 
     # Rerun when failed, use 'unused' tag because of following issue:
     # https://github.com/coreos/coreos-assembler/issues/4546
-    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused
+    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused --denylist-test iso.*iscsi*
 }
 
 # Helper function to run the standard build and test workflow

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -245,17 +245,23 @@ main() {
             cosa_init "$2"
             ;;
         # this is called by cosa's CI
-        "rhcos-9-build-test"|"rhcos-cosa-prow-pr-ci"|"rhcos-9-build-test-qemu"|"rhcos-9-build-test-metal")
+        "rhcos-9-build-test"|"rhcos-cosa-prow-pr-ci"|"rhcos-9-build-test-metal")
             run_build_test "rhel-9.8"
             ;;
-        "scos-9-build-test"|"scos-9-build-test-qemu"|"scos-9-build-test-metal")
+        "scos-9-build-test"|"scos-9-build-test-metal")
             run_build_test "c9s"
             ;;
-        "scos-10-build-test"|"scos-10-build-test-qemu"|"scos-10-build-test-metal")
+        "scos-10-build-test"|"scos-10-build-test-metal")
             run_build_test "c10s"
             ;;
-        "rhcos-10-build-test"|"rhcos-10-build-test-qemu"|"rhcos-10-build-test-metal")
+        "rhcos-10-build-test"|"rhcos-10-build-test-metal")
             run_build_test "rhel-10.2"
+            ;;
+        # Keep standalone qemu jobs green while the same coverage is
+        # provided by the corresponding metal jobs.
+        "rhcos-9-build-test-qemu"|"rhcos-10-build-test-qemu"|"scos-9-build-test-qemu"|"scos-10-build-test-qemu")
+            echo "Skipping standalone qemu job; coverage is provided by the corresponding metal job"
+            return 0
             ;;
         *)
             # This case ensures that we exhaustively list the tests that should

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -99,8 +99,15 @@ kola_test_metal() {
     # installs with the image format we ship
     cosa compress --artifact=metal --artifact=metal4k
 
-    # Run all testiso scenarios on metal artifact
-    kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso  --denylist-test iso-offline-install-iscsi* --denylist-test pxe-offline-install.rootfs-appended.bios
+    # Use 'testiso' for older cosa builds, otherwise use kola.
+    # Until RHCOS openshift cluster gets updated, iso.* tests run sequentially.
+    if cosa kola help | grep -q testiso; then
+        cosa kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso --denylist-test iso-offline-install-iscsi* --denylist-test pxe-offline-install.rootfs-appended.bios
+    else
+        # Rerun when failed, use 'unused' tag because of following issue:
+        # https://github.com/coreos/coreos-assembler/issues/4546
+        cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused
+    fi
 }
 
 # Basic syntaxt validation for manifests

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -90,7 +90,7 @@ kola() {
 
     # Rerun when failed, use 'unused' tag because of following issue:
     # https://github.com/coreos/coreos-assembler/issues/4546
-    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused --denylist-test iso.*iscsi*
+    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused --denylist-test iso.*iscsi* --denylist-test iso.pxe-*.rootfs-appended*
 }
 
 # Helper function to run the standard build and test workflow

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -86,17 +86,12 @@ cosa_build() {
 
 # Run all kola tests
 kola() {
+    # Until RHCOS openshift cluster gets updated, iso.* tests run sequentially, so skip them here
     cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet --denylist-test iso.*
 
-    # Use 'testiso' for older cosa builds, otherwise use kola.
-    # Until RHCOS openshift cluster gets updated, iso.* tests run sequentially.
-    if cosa kola help | grep -q testiso; then
-        cosa kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso --denylist-test iso-offline-install-iscsi* --denylist-test pxe-offline-install.rootfs-appended.bios
-    else
-        # Rerun when failed, use 'unused' tag because of following issue:
-        # https://github.com/coreos/coreos-assembler/issues/4546
-        cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused
-    fi
+    # Rerun when failed, use 'unused' tag because of following issue:
+    # https://github.com/coreos/coreos-assembler/issues/4546
+    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused
 }
 
 # Helper function to run the standard build and test workflow

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -85,12 +85,9 @@ cosa_build() {
 }
 
 # Run all kola tests
-kola_test_qemu() {
-    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet
-}
+kola() {
+    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet --denylist-test iso.*
 
-# Run kola iso.* tests
-kola_test_metal() {
     # Use 'testiso' for older cosa builds, otherwise use kola.
     # Until RHCOS openshift cluster gets updated, iso.* tests run sequentially.
     if cosa kola help | grep -q testiso; then
@@ -100,6 +97,15 @@ kola_test_metal() {
         # https://github.com/coreos/coreos-assembler/issues/4546
         cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused
     fi
+}
+
+# Helper function to run the standard build and test workflow
+run_build_test() {
+    local -r variant="${1}"
+    setup_user
+    cosa_init "${variant}"
+    cosa_build
+    kola
 }
 
 # Basic syntaxt validation for manifests
@@ -245,59 +251,17 @@ main() {
             cosa_init "$2"
             ;;
         # this is called by cosa's CI
-        "rhcos-cosa-prow-pr-ci")
-            setup_user
-            cosa_init "rhel-9.8"
-            cosa_build
-            kola_test_qemu
+        "rhcos-cosa-prow-pr-ci"|"rhcos-9-build-test-qemu"|"rhcos-9-build-test-metal")
+            run_build_test "rhel-9.8"
             ;;
-        "rhcos-9-build-test-qemu")
-            setup_user
-            cosa_init "rhel-9.8"
-            cosa_build
-            kola_test_qemu
+        "scos-9-build-test-qemu"|"scos-9-build-test-metal")
+            run_build_test "c9s"
             ;;
-        "rhcos-9-build-test-metal")
-            setup_user
-            cosa_init "rhel-9.8"
-            cosa_build
-            kola_test_metal
+        "scos-10-build-test-qemu"|"scos-10-build-test-metal")
+            run_build_test "c10s"
             ;;
-        "scos-9-build-test-qemu")
-            setup_user
-            cosa_init "c9s"
-            cosa_build
-            kola_test_qemu
-            ;;
-        "scos-9-build-test-metal")
-            setup_user
-            cosa_init "c9s"
-            cosa_build
-            kola_test_metal
-            ;;
-        "scos-10-build-test-qemu")
-            setup_user
-            cosa_init "c10s"
-            cosa_build
-            kola_test_qemu
-            ;;
-        "scos-10-build-test-metal")
-            setup_user
-            cosa_init "c10s"
-            cosa_build
-            kola_test_metal
-            ;;
-        "rhcos-10-build-test-qemu")
-            setup_user
-            cosa_init "rhel-10.2"
-            cosa_build
-            kola_test_qemu
-            ;;
-        "rhcos-10-build-test-metal")
-            setup_user
-            cosa_init "rhel-10.2"
-            cosa_build
-            kola_test_metal
+        "rhcos-10-build-test-qemu"|"rhcos-10-build-test-metal")
+            run_build_test "rhel-10.2"
             ;;
         *)
             # This case ensures that we exhaustively list the tests that should

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -245,16 +245,16 @@ main() {
             cosa_init "$2"
             ;;
         # this is called by cosa's CI
-        "rhcos-cosa-prow-pr-ci"|"rhcos-9-build-test-qemu"|"rhcos-9-build-test-metal")
+        "rhcos-9-build-test"|"rhcos-cosa-prow-pr-ci"|"rhcos-9-build-test-qemu"|"rhcos-9-build-test-metal")
             run_build_test "rhel-9.8"
             ;;
-        "scos-9-build-test-qemu"|"scos-9-build-test-metal")
+        "scos-9-build-test"|"scos-9-build-test-qemu"|"scos-9-build-test-metal")
             run_build_test "c9s"
             ;;
-        "scos-10-build-test-qemu"|"scos-10-build-test-metal")
+        "scos-10-build-test"|"scos-10-build-test-qemu"|"scos-10-build-test-metal")
             run_build_test "c10s"
             ;;
-        "rhcos-10-build-test-qemu"|"rhcos-10-build-test-metal")
+        "rhcos-10-build-test"|"rhcos-10-build-test-qemu"|"rhcos-10-build-test-metal")
             run_build_test "rhel-10.2"
             ;;
         *)


### PR DESCRIPTION
All iso tests were folded into the rest of the kola test code, so `testiso` command no longer exists.

https://github.com/coreos/coreos-assembler/issues/3989