### PR TITLE
common: Disable empty password authentication via authselect without-nullok

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -114,7 +114,8 @@ postprocess:
     # We're not using resolved yet
     rm -f /usr/lib/systemd/system/systemd-resolved.service
 
-  # This updates the PAM configuration to reference all of the SSSD modules.
+  # This updates the PAM configuration to reference all of the SSSD modules
+  # and applies without-nullok to disable empty password authentication.
   # authselect requires access to /var and more permissions to enable a profile,
   # so we use 'authselect test' instead.
 
@@ -122,10 +123,15 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     # use `authselect test` since `authselect select` wants to copy to `/var` too
-    authselect test sssd --nsswitch | tail -n +2 > /etc/nsswitch.conf
+    authselect test sssd without-nullok --nsswitch | tail -n +2 > /etc/nsswitch.conf
     for pam_file in system-auth password-auth smartcard-auth fingerprint-auth postlogin; do
-      authselect test sssd --${pam_file} | tail -n +2 > /etc/pam.d/${pam_file}
+      authselect test sssd without-nullok --${pam_file} | tail -n +2 > /etc/pam.d/${pam_file}
     done
+    # Verify nullok was removed from all PAM auth files
+    if grep -q nullok /etc/pam.d/{system,password,smartcard,fingerprint}-auth /etc/pam.d/postlogin; then
+      echo "ERROR: nullok still present in PAM configuration after authselect" >&2
+      exit 1
+    fi
 
   - |
     #!/usr/bin/env bash


### PR DESCRIPTION
RHCOS inherits `nullok` in PAM from the RHEL defaults, which permits authentication with empty passwords. While RHCOS nodes don't set a root password by default, `nullok` still allows authentication with empty passwords for any account where one is explicitly set. Removing it is a defense-in-depth measure consistent with all major compliance profiles.

This adds `without-nullok` to the existing `authselect test sssd` calls in the postprocess block, plus a verification step. The change is minimal — adding one authselect feature flag to the existing PAM configuration step.

### Why this change

This is flagged as a HIGH severity finding across every compliance profile that applies to RHCOS: Essential 8, CIS, NIST Moderate, and PCI-DSS. Unlike many hardening recommendations where benchmarks disagree, removing `nullok` is consistent across all of them.

Today, the compliance-operator remediation for this finding is broken on RHCOS 9 — it generates RHEL 8 era PAM templates that don't apply cleanly. Fixing it at the image level eliminates the issue for all clusters without requiring per-node MachineConfig remediation.

### Why the maintenance burden is low

- Uses authselect's `without-nullok` feature flag — the supported RHEL mechanism purpose-built for this ([authselect/authselect#94](https://github.com/authselect/authselect/issues/94), landed in 2018)
- Adds one parameter to the existing `authselect test sssd` calls — no new postprocess block, no custom PAM files
- Includes a verification step that fails the build if nullok persists

### Scope

This is intentionally narrow. We understand the concern about carrying hardening overrides that diverge from RHEL defaults. This is not a campaign to upstream every compliance checklist item.

Moved from https://github.com/openshift/os/pull/1934 per maintainer feedback.

### References

- `without-nullok` feature: https://github.com/authselect/authselect/commit/e1fbbdc
- Upstream scanner fix: https://github.com/ComplianceAsCode/content/pull/14602
- Previous PR: https://github.com/openshift/os/pull/1934
- Hardening group tracker: https://sebrandon1.github.io/compliance-scripts/versions/4.22/groups/H2