### PR TITLE
NO-JIRA: denylist: snooze ext.config.rpm-ostree.replace-rt-kernel and ext.config.kdump.kernel-rt-crash on c10s

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,3 +11,16 @@
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: pxe-offline-install.rootfs-appended.bios
 #  tracker: https://github.com/openshift/os/issues/1768
+
+- pattern: ext.config.kdump.kernel-rt-crash
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/254
+  snooze: 2026-05-31
+  warn: true
+  streams:
+    - c10s
+- pattern: ext.config.rpm-ostree.replace-rt-kernel
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/254
+  snooze: 2026-05-31
+  warn: true
+  streams:
+    - c10s


### PR DESCRIPTION
These tests are currently failing on c10s due to an issue with the iptables rpm spec. Let's snooze these while we work on resolving the issue.

See https://github.com/coreos/rhel-coreos-config/issues/254