### PR TITLE
NO-JIRA: denylist: snooze rpm-ostree.replace-rt-kernel and kernel-rt-crash on rhel-10.2

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,10 +17,12 @@
   snooze: 2026-05-31
   warn: true
   streams:
+    - rhel-10.2
     - c10s
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/coreos/rhel-coreos-config/issues/254
   snooze: 2026-05-31
   warn: true
   streams:
+    - rhel-10.2
     - c10s


### PR DESCRIPTION
These tests are currently failing on due to an issue with the iptables rpm spec

PR https://github.com/coreos/rhel-coreos-config/pull/257 disabled these for c10s, but they need to be snoozed for rhel-10.2 as well

See: https://github.com/coreos/rhel-coreos-config/issues/254