### PR TITLE
OCPBUGS-64660: overlay/40rhcos-fips: Update crypto-policies on RHEL10

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -69,29 +69,32 @@ finish() {
         fatal "FIPS mode is not enabled."
     fi
 
-    # on EL10 fips-mode-setup was removed and these steps are
-    # no longer needed. Please delete this function and sysroot_bwrap
-    # when EL9 is no longer supported.
-    if [ ! -e /sysroot/usr/bin/fips-mode-setup ]; then
-        return 0
-    fi
-
-    # If we're running from a live system, then set things up so that the dracut fips
-    # module will find the kernel binary.  TODO change dracut to look in /usr/lib/modules/$(uname -r)
-    # directly.
+    # The dracut 01fips module's do_fips() function checks for the
+    # kernel at /run/initramfs/live/vmlinuz0 for HMAC integrity
+    # verification. ISO images do not have the kernel saved in that
+    # path, so we will add a symlink.
+    #
+    # TODO: change dracut to look in /usr/lib/modules/$(uname -r) directly
+    # See: https://github.com/dracut-ng/dracut/blob/02e7ae10830d1268f1acdf879ef14d5b6bc89ac3/modules.d/11fips/fips.sh#L177
     if test -f /etc/coreos-live-initramfs; then
-        # See the dracut source
         rhevh_livedir=/run/initramfs/live
         mkdir -p "${rhevh_livedir}"
-        # Why "vmlinuz0"?  I have no idea; it's what the dracut fips module uses.
         ln -sr /usr/lib/modules/$(uname -r)/vmlinuz ${rhevh_livedir}/vmlinuz0
     fi
 
-    # This is analogous to Anaconda's `chroot /sysroot fips-mode-setup`. Though
-    # of course, since our approach is "Ignition replaces Anaconda", we have to
-    # do it on firstboot ourselves. The key part here is that we do this
-    # *before* the initial switch root.
-    sysroot_bwrap fips-mode-setup --enable --no-bootcfg
+    # Configure the FIPS crypto-policy on disk via sysroot_bwrap,
+    # analogous to Anaconda's chroot into /sysroot. The key part
+    # here is that we do this *before* the initial switch root.
+    #
+    # On EL9, fips-mode-setup configures the crypto-policy on disk.
+    #
+    # On EL10, fips-mode-setup was removed (RHEL-65652), so we call
+    # update-crypto-policies directly.
+    if [ -e /sysroot/usr/bin/fips-mode-setup ]; then
+        sysroot_bwrap fips-mode-setup --enable --no-bootcfg
+    else
+        sysroot_bwrap update-crypto-policies --set FIPS
+    fi
 }
 
 sysroot_bwrap() {


### PR DESCRIPTION
On RHEL10, `fips-mode-setup` was removed[1]. Currently, `rhcos-fips.sh` will return early without configuring the crypto-policy on disk, letting the `fips-crypto-policies`[2] dracut module set up read-only bind mounts over /etc/crypto-policies as a fallback.

Instead, call `update-crypto-policies --set FIPS` directly, writting the config on-disk.

Really, we want to call `fips-setup-helper` [3], which would then call the above command for us, and let the crypto team that we are using it. We could call it directly for now, and change it to use the `fips-setup-helper` when it accepts coreos as context, or we can wait.

[1] https://redhat.atlassian.net/browse/RHEL-65652

[2] https://github.com/dracut-ng/dracut/blob/02e7ae10830d1268f1acdf879ef14d5b6bc89ac3/modules.d/11fips-crypto-policies/fips-crypto-policies.sh

[3] https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/blob/master/fips-setup-helper

Fixes: https://github.com/openshift/os/issues/1665