### PR TITLE
NO-JIRA: denylist: snooze install-bootloader-multipath on c9s aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -24,3 +24,11 @@
   warn: true
   streams:
     - c10s
+- pattern: ext.config.shared.boot.install-bootloader-multipath
+  tracker: https://issues.redhat.com/browse/COS-4364
+  snooze: 2026-06-30
+  warn: true
+  streams:
+    - c9s
+  arches:
+    - aarch64


### PR DESCRIPTION
Pipeline has been failing for a couple of days, snooze until issue is resolved.

Issue: https://issues.redhat.com/browse/COS-4364