### PR TITLE
NO-JIRA: denylist: drop entries for `kernel-rt-crash` and `replace-rt-kernel`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -19,16 +19,3 @@
   snooze: 2026-07-16
   streams:
     - rhel-10.2
-
-- pattern: ext.config.kdump.kernel-rt-crash
-  tracker: https://github.com/coreos/rhel-coreos-config/issues/254
-  snooze: 2026-05-31
-  warn: true
-  streams:
-    - c10s
-- pattern: ext.config.rpm-ostree.replace-rt-kernel
-  tracker: https://github.com/coreos/rhel-coreos-config/issues/254
-  snooze: 2026-05-31
-  warn: true
-  streams:
-    - c10s


### PR DESCRIPTION
Since the repos have been updated with iptables-nft 1.8.11-14.el10, these tests now pass on c10s. Let's drop these entries as they're no longer required.

See #254 