### PR TITLE
overlay/05rhcos: Add sysctl security hardening defaults

### DIFF
--- a/overlay.d/05rhcos/usr/lib/sysctl.d/50-rhcos-security.conf
+++ b/overlay.d/05rhcos/usr/lib/sysctl.d/50-rhcos-security.conf
@@ -1,0 +1,10 @@
+# Restrict access to kernel ring buffer to processes with CAP_SYSLOG.
+# Unprivileged users have no legitimate need to read dmesg on a
+# container host.
+# CIS Benchmark: Ensure kernel log access is restricted
+kernel.dmesg_restrict = 1
+
+# Harden BPF JIT compiler to prevent JIT spraying attacks.
+# KSPP recommended setting with negligible performance impact.
+# CIS Benchmark: Ensure BPF JIT hardening is enabled
+net.core.bpf_jit_harden = 2


### PR DESCRIPTION
RHCOS ships with kernel defaults for `dmesg_restrict` (0) and `bpf_jit_harden` (0) inherited from RHEL. Both are universally recommended hardening settings for server systems with zero functional impact on container host workloads.

This adds a sysctl drop-in at `overlay.d/05rhcos/usr/lib/sysctl.d/50-rhcos-security.conf` with two settings, following the same pattern as Fedora CoreOS's existing [`10-coreos-ratelimit-kmsg.conf`](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/overlay.d/05core/usr/lib/sysctl.d/10-coreos-ratelimit-kmsg.conf).

### Settings

- **`kernel.dmesg_restrict=1`** ([CCE-82499-5](https://github.com/ComplianceAsCode/content/tree/master/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict)): Restricts kernel ring buffer access to processes with `CAP_SYSLOG`. Unprivileged users have no legitimate need to read dmesg on a container host. Already the default in [Debian](https://salsa.debian.org/kernel-team/linux/-/blob/master/debian/config/kernelarch-x86/config#L6059) and Ubuntu. References: [NIST SP 800-53 SI-11](https://csf.tools/reference/nist-sp-800-53/r5/si/si-11/), [SRG-OS-000132-GPOS-00067](https://www.stigviewer.com/srg/SRG-OS-000132-GPOS-00067/).

- **`net.core.bpf_jit_harden=2`** ([CCE-82505-9](https://github.com/ComplianceAsCode/content/tree/master/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden)): Hardens the BPF JIT compiler against [JIT spraying attacks](https://googleprojectzero.blogspot.com/2018/01/reading-privileged-memory-with-side.html). Recommended by the [Kernel Self-Protection Project](https://kspp.github.io/Recommended_Settings) with negligible performance impact. References: [NIST SP 800-53 SC-7(10)](https://csf.tools/reference/nist-sp-800-53/r5/sc/sc-7/sc-7-10/), [SRG-OS-000480-GPOS-00227](https://www.stigviewer.com/srg/SRG-OS-000480-GPOS-00227/).

### Why this change

Both settings are included in the [RHCOS4 Essential Eight profile](https://github.com/ComplianceAsCode/content/blob/master/products/rhcos4/profiles/e8.profile) used by the [compliance-operator](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator) when scanning RHCOS nodes. Today, remediating them requires per-cluster [MachineConfig](https://docs.openshift.com/container-platform/4.17/post_installation_configuration/machine-configuration-tasks.html) deployment. Setting them at the image level eliminates that for all clusters.

### Why the maintenance burden is low

- Two standard sysctl values in a single drop-in file — no scripts, no postprocess logic
- Both are static kernel tunables with no version-dependent behavior
- No interaction with other RHCOS components or RHEL defaults beyond the two values they override

### Scope

This is intentionally narrow — two settings, one file. Consistent with the approach discussed in [#255](https://github.com/coreos/rhel-coreos-config/pull/255).

### References

- ComplianceAsCode rule: [`sysctl_kernel_dmesg_restrict`](https://github.com/ComplianceAsCode/content/tree/master/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict)
- ComplianceAsCode rule: [`sysctl_net_core_bpf_jit_harden`](https://github.com/ComplianceAsCode/content/tree/master/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden)
- KSPP recommended settings: https://kspp.github.io/Recommended_Settings
- FCOS precedent: [`10-coreos-ratelimit-kmsg.conf`](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/overlay.d/05core/usr/lib/sysctl.d/10-coreos-ratelimit-kmsg.conf)
