### PR TITLE
ci/prow: execute iso tests in primary kola run

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -85,12 +85,11 @@ cosa_build() {
 
 # Run all kola tests
 kola() {
-    # Until RHCOS openshift cluster gets updated, iso.* tests run sequentially, so skip them here
-    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet --denylist-test iso.*
+    # Execute kola tests. Skip iso.* tests here as we run them below sequentially.
+    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --denylist-test iso.*
 
-    # Rerun when failed, use 'unused' tag because of following issue:
-    # https://github.com/coreos/coreos-assembler/issues/4546
-    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --allow-rerun-success tags=unused --denylist-test iso.*iscsi* --denylist-test iso.pxe-*.rootfs-appended*
+    # Execute .iso kola tests serially.
+    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --denylist-test iso.*iscsi* --denylist-test iso.pxe-*.rootfs-appended*
 }
 
 # Helper function to run the standard build and test workflow

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -86,7 +86,7 @@ cosa_build() {
 # Run all kola tests
 kola() {
     # Execute kola tests.
-    cosa kola run --parallel auto --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --denylist-test iso.*iscsi* --denylist-test iso.pxe-*.rootfs-appended*
+    cosa kola run --parallel auto --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun
 }
 
 # Helper function to run the standard build and test workflow

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -85,11 +85,8 @@ cosa_build() {
 
 # Run all kola tests
 kola() {
-    # Execute kola tests. Skip iso.* tests here as we run them below sequentially.
-    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --denylist-test iso.*
-
-    # Execute .iso kola tests serially.
-    cosa kola run --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso iso.* --rerun --denylist-test iso.*iscsi* --denylist-test iso.pxe-*.rootfs-appended*
+    # Execute kola tests.
+    cosa kola run --parallel auto --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --denylist-test iso.*iscsi* --denylist-test iso.pxe-*.rootfs-appended*
 }
 
 # Helper function to run the standard build and test workflow


### PR DESCRIPTION
With [1] we are giving more resources to the test runs so
we should be able to execute everything in parallel and have
the kola schedule things based on available resources.

[1] https://github.com/openshift/release/pull/80166
