### PR TITLE
COS-4483: manifest/10.2: pin kernel version to 6.12.0-211.7.1.el10_2 to avoid cri-o startup failure

### DIFF
--- a/manifest-rhel-10.2.yaml
+++ b/manifest-rhel-10.2.yaml
@@ -19,3 +19,9 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-process script
  - redhat-release
+ # Work around CVE-2026-46054 fix (RHEL-179437) in 6.12.0-211.22.1 which introduces
+ # an issue on composefs - selinux evaluates the wrong security context
+ # for binaries, breaking CRI-O startup on x86_64.
+ # See https://bugzilla.redhat.com/show_bug.cgi?id=2477939
+ # Revert once a RHEL 10.2 kernel with a composefs-compatible fix lands.
+ - kernel-6.12.0-211.7.1.el10_2


### PR DESCRIPTION
Unblock rhcos-10 by pinning kernel to known working version. See https://redhat.atlassian.net/browse/COS-4483