### PR TITLE
COS-4500: overrides: Pin sssd-2.9.9-1.el9

### DIFF
--- a/packages-overrides.yaml
+++ b/packages-overrides.yaml
@@ -3,6 +3,15 @@
 # RPMs) and list the NEVRs we need in the `packages` section. When not needed comment
 # out the sections below.
 conditional-include:
+# newer versions of sssd will require samba-client-libs >= 4.24.3, which is not
+# yet available. Pin sssd to the prior version to avoid this dependency issue.
+# For full error, see: https://github.com/coreos/rhel-coreos-config/pull/270
+- if: osversion == "centos-9"
+  include:
+    repos:
+      - c9s-baseos-mirror
+    packages:
+      - sssd-2.9.9-1.el9
 ##- if: osversion == "centos-9"
 ##  include:
 ##    repos:


### PR DESCRIPTION
The newer sssd-2.9.9-2.el9 requires sssd-ipa = 2.9.9-2.el9, which in turn requires samba-client-libs >= 4.24.3 which is not yet available in c9s-baseos. Until it become available, pinning sssd solves the issue.

Issue we are seeing in pipeline:
```
rpm-md repo 'c9s-baseos'; generated: 2026-06-16T04:09:49Z solvables: 922
rpm-md repo 'c9s-appstream'; generated: 2026-06-16T04:09:12Z solvables: 5185
rpm-md repo 'c9s-extras-common'; generated: 2026-06-10T14:05:56Z solvables: 105
Resolving dependencies...done
error: Installing packages: Could not depsolve transaction; 1 problem detected:
 Problem: package sssd-2.9.9-2.el9.aarch64 from c9s-baseos requires sssd-ipa = 2.9.9-2.el9, but none of the providers can be installed
  - conflicting requests
  - nothing provides samba-client-libs >= 4.24.3 needed by sssd-ipa-2.9.9-2.el9.aarch64 from c9s-baseos
```