### PR TITLE
tests: add kola test for systemd-sysusers group consistency

### DIFF
--- a/tests/kola/systemd/sysusers-group-consistency
+++ b/tests/kola/systemd/sysusers-group-consistency
@@ -1,0 +1,26 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   description: Verify group/gshadow consistency and that the containers
+##     user/group is properly defined for the RHCOS image layering split.
+##     https://issues.redhat.com/browse/OCPBUGS-64841
+
+set -xeuo pipefail
+
+. "${KOLA_EXT_DATA}/commonlib.sh"
+
+# The containers user/group (uid/gid 790) is defined in altfiles
+# (/usr/lib/passwd, /usr/lib/group) and resolved via nss-altfiles.
+# Verify they resolve correctly.
+if ! id containers > /dev/null 2>&1; then
+    fatal "containers user does not resolve"
+fi
+ok "containers user resolves"
+
+# Verify uid/gid is 790
+containers_uid=$(id -u containers)
+containers_gid=$(id -g containers)
+if [ "$containers_uid" != "790" ] || [ "$containers_gid" != "790" ]; then
+    fatal "containers uid/gid expected 790/790, got ${containers_uid}/${containers_gid}"
+fi
+ok "containers uid/gid is 790/790"


### PR DESCRIPTION
Add a kola test that verifies systemd-sysusers.service completes successfully and that /etc/group and /etc/gshadow remain consistent with no duplicate entries. Also, it validates the containers user and group resolve via nss-altfiles (uid/gid 790) as required by CRI-O.

This is a regression test for the issue where the RHCOS image layering split (base RHEL + OCP node layer) caused the containers group to not be properly created which lead to systemd-sysusers failures on nodes upgrading from OCP 4.18 and earlier.

Ref:
https://redhat.atlassian.net/browse/ECOENGCL-465
https://issues.redhat.com/browse/OCPBUGS-64841