### PR TITLE
NO-JIRA: manifests: drop redundant definitions with fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,11 +1,5 @@
 # We inherit from Fedora CoreOS' base configuration
 include:
-  - fedora-coreos-config/manifests/system-configuration.yaml
-  - fedora-coreos-config/manifests/ignition-and-ostree.yaml
-  - fedora-coreos-config/manifests/file-transfer.yaml
-  - fedora-coreos-config/manifests/networking-tools.yaml
-  - fedora-coreos-config/manifests/user-experience.yaml
-  - fedora-coreos-config/manifests/coreos-bootc-delta.yaml
   - fedora-coreos-config/manifests/shared-el.yaml
   # RHCOS owned packages
   - packages-rhcos.yaml
@@ -13,18 +7,14 @@ include:
 
 # Layers common to all versions of RHCOS and SCOS
 ostree-layers:
-  - overlay/01fcos
-  - overlay/02fcos-nouveau
-  - overlay/05rhcos
-  - overlay/06gcp-routes
-  - overlay/15rhcos-networkmanager-dispatcher
-  - overlay/15rhcos-tuned-bits
-  - overlay/15rhcos-journald-backcompat
-  - overlay/20platform-chrony
-  - overlay/21dhcp-chrony
-  - overlay/30rhcos-nvme-compat-udev
-  - overlay/30gcp-udev-rules
-  - overlay/30lvmdevices
+  - overlay.d/05rhcos
+  - overlay.d/06gcp-routes
+  - overlay.d/15rhcos-networkmanager-dispatcher
+  - overlay.d/15rhcos-tuned-bits
+  - overlay.d/15rhcos-journald-backcompat
+  - overlay.d/21dhcp-chrony
+  - overlay.d/30rhcos-nvme-compat-udev
+  - overlay.d/30gcp-udev-rules
 
 conditional-include:
   # Configuration specific to el9

--- a/manifest-el9-shared.yaml
+++ b/manifest-el9-shared.yaml
@@ -39,7 +39,7 @@ conditional-include:
 ostree-layers:
   # Configure plugin order for NetworkManager config files. EL9 only as
   # `ifcfg-rh` has been dropped in EL10.
-  - overlay/15rhcos-networkmanager-plugin-order
+  - overlay.d/15rhcos-networkmanager-plugin-order
 
 postprocess:
   # zram-generator-0.3.2 (shipped in centOS 9) provides a default zram-generator

--- a/overlay.d/01fcos
+++ b/overlay.d/01fcos
@@ -1,1 +1,0 @@
-../fedora-coreos-config/overlay.d/05core

--- a/overlay.d/02fcos-nouveau
+++ b/overlay.d/02fcos-nouveau
@@ -1,1 +1,0 @@
-../fedora-coreos-config/overlay.d/08nouveau

--- a/overlay.d/20platform-chrony
+++ b/overlay.d/20platform-chrony
@@ -1,1 +1,0 @@
-../fedora-coreos-config/overlay.d/20platform-chrony

--- a/overlay.d/30lvmdevices
+++ b/overlay.d/30lvmdevices
@@ -1,1 +1,0 @@
-../fedora-coreos-config/overlay.d/30lvmdevices


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-config/pull/4227 we reworked things upstream to define more of what is defined in rhel-coreos-config in the shared-el.yaml manifest.

This means we can manage the definition of the "fedora-coreos pieces" of the rhel-coreos-config directly upstream and changes to that definition are self contained and brought in via submodule bumps.

This commit adjusts the defnitions here to drop the pieces that are now redundant because they are defined upstream in shared-el.yaml.