### PR TITLE
NO-JIRA: 05fcos/rhcos-fips: mute FIPS errors that are not needed

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -91,7 +91,10 @@ finish() {
     # On EL10, fips-mode-setup was removed (RHEL-65652), so we call
     # update-crypto-policies directly.
     if [ -e /sysroot/usr/bin/fips-mode-setup ]; then
-        sysroot_bwrap fips-mode-setup --enable --no-bootcfg
+        sysroot_bwrap env                                   \
+                      FIPS_MODE_SETUP_SKIP_WARNING=1        \
+                      FIPS_MODE_SETUP_SKIP_ARGON2_CHECK=1   \
+                      fips-mode-setup --enable --no-bootcfg
     else
         sysroot_bwrap update-crypto-policies --set FIPS
     fi


### PR DESCRIPTION
fips-mode-setup prints a scary error messages and sleeps for 15 seconds. Both checks are unnecessary for RHCOS, so we can disable them by setting env variables.

Closes: #262