### PR TITLE
NO-JIRA: denylist: add entry for ext.config.boot.raid1-boot.ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,3 +11,10 @@
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: pxe-offline-install.rootfs-appended.bios
 #  tracker: https://github.com/openshift/os/issues/1768
+
+- pattern: ext.config.boot.raid1-boot.ppc64le
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/281
+  warn: true
+  snooze: 2026-07-15
+  arches:
+    - ppc64le


### PR DESCRIPTION
This test has been added upstream, but our variants here won't yet have the patched grub2 available. Let's add a denylist entry while we wait.

See #281