### PR TITLE
NO-JIRA: test/denylist: Increase raid1 boot snooze date and fix pattern

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,9 +12,9 @@
 #- pattern: pxe-offline-install.rootfs-appended.bios
 #  tracker: https://github.com/openshift/os/issues/1768
 
-- pattern: ext.config.boot.raid1-boot.ppc64le
+- pattern: ext.config.shared.boot.raid1-boot.ppc64le
   tracker: https://github.com/coreos/rhel-coreos-config/issues/281
   warn: true
-  snooze: 2026-07-15
+  snooze: 2026-07-29
   arches:
     - ppc64le


### PR DESCRIPTION
In `rhel` the pattern needs to include `shared`, this adds that and also increases the snooze since its unlikely that the fix will arrive before the current snooze ends.